### PR TITLE
Make dropdowns open on hover without JS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,25 +108,27 @@ layout: compress
 					{% endif %}
 					{% if item.items %}
 						{% assign submenu = item.title | append: "Submenu" | replace: " ", "" %}
-						<li {% for entry in item.items %}{% if entry.url == page.permalink %}class="active"{% endif %}{% endfor %}>
-							<a href="#{{ submenu }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle proxim">
-								{% if item.icon %}
-									{% if item.notif %}
-										<span class="fa fa-fw fa-{{ item.icon }} mr-1 notif">
-											<small class="badge rounded-pill bg-danger d-flex justify-content-center">{{ item.notif }}</small>
-										</span>
-									{% else %}
-										<span class="fa fa-fw fa-{{ item.icon }} mr-1"></span>
-									{% endif %}
-								{% elsif item.image %}
-									<img src="{{item.image}}" class="mr-2">
-								{% endif %} {{ item.title }}</a>
-							<ul class="collapse list-unstyled" id="{{ submenu }}">
-								{% for entry in item.items %}
-									<li {% if entry.url == page.permalink %}class="active"{% endif %}><a href="{{entry.url}}">{{entry.title}}</a></li>
-								{% endfor %}
-							</ul>
-						</li>
+						<noscript><div class="dropdown"></noscript>
+							<li {% for entry in item.items %}{% if entry.url == page.permalink %}class="active"{% endif %}{% endfor %}>
+								<a href="#{{ submenu }}" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle proxim">
+									{% if item.icon %}
+										{% if item.notif %}
+											<span class="fa fa-fw fa-{{ item.icon }} mr-1 notif">
+												<small class="badge rounded-pill bg-danger d-flex justify-content-center">{{ item.notif }}</small>
+											</span>
+										{% else %}
+											<span class="fa fa-fw fa-{{ item.icon }} mr-1"></span>
+										{% endif %}
+									{% elsif item.image %}
+										<img src="{{item.image}}" class="mr-2">
+									{% endif %} {{ item.title }}</a>
+								<ul class="collapse list-unstyled" id="{{ submenu }}">
+									{% for entry in item.items %}
+										<li {% if entry.url == page.permalink %}class="active"{% endif %}><a href="{{entry.url}}">{{entry.title}}</a></li>
+									{% endfor %}
+								</ul>
+							</li>
+						<noscript></div></noscript>
 					{% endif %}
 				{% endfor %}
 			</ul>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -508,3 +508,7 @@ img {
 #contactMeButtons a img {
 	height: 2rem;
 }
+
+.dropdown:hover .collapse {
+	display: block!important;
+}


### PR DESCRIPTION
This isn't technically valid HTML and its kinda gross code ngl, but its the easiest way to do this, basically just treating the <noscript> tags as comments. It does work as expected in Safari, Firefox, and Edge at least, the dropdowns open when hovering if JS is off and on click when its on, but feel free to decline this if you don't like using hacky solution ;P

Edit: Doing this more properly I think would either require a second copy of the \<li\> or so, or use JS to remove the "dropdown" class from the \<li\> at runtime, both of which are more proper, but require more work and I'm lazy ;P