### PR TITLE
Fix languages SVG in Safari

### DIFF
--- a/assets/js/github.js
+++ b/assets/js/github.js
@@ -95,7 +95,7 @@ export default async function (elements) {
 				})
 
 			wideLangBox
-				.querySelector("mask")
+				.querySelector("mask#rect-mask")
 				.firstElementChild
 				.setAttribute("width", WideBoxBarWidth)
 
@@ -131,7 +131,7 @@ export default async function (elements) {
 				})
 
 			tallLangBox
-				.querySelector("mask")
+				.querySelector("mask#rect-mask")
 				.firstElementChild
 				.setAttribute("width", tallBoxBarWidth)
 

--- a/assets/js/github.js
+++ b/assets/js/github.js
@@ -94,10 +94,17 @@ export default async function (elements) {
 					WideBoxBarWidth = WideBoxBarWidth.plus(WideBoxRectWidth);
 				})
 
-			wideLangBox
-				.querySelector("mask#rect-mask")
-				.firstElementChild
-				.setAttribute("width", WideBoxBarWidth)
+			try {
+				wideLangBox
+					.getElementById("rect-mask")
+					.firstElementChild
+					.setAttribute("width", WideBoxBarWidth)
+			} catch(e) {
+				wideLangBox
+					.querySelector("mask#rect-mask")
+					.firstElementChild
+					.setAttribute("width", WideBoxBarWidth)
+			}
 
 			let i = 0;
 			wideLangBox
@@ -130,10 +137,17 @@ export default async function (elements) {
 					tallBoxBarWidth = tallBoxBarWidth.plus(tallBoxRectWidth);
 				})
 
-			tallLangBox
-				.querySelector("mask#rect-mask")
-				.firstElementChild
-				.setAttribute("width", tallBoxBarWidth)
+			try {
+				tallLangBox
+					.getElementById("rect-mask")
+					.firstElementChild
+					.setAttribute("width", tallBoxBarWidth)
+			} catch(e) {
+				tallLangBox
+					.querySelector("mask#rect-mask")
+					.firstElementChild
+					.setAttribute("width", tallBoxBarWidth)
+			}
 
 			element.insertAdjacentElement('afterend', tallLangBox)
 			element.insertAdjacentElement('afterend', wideLangBox)

--- a/assets/js/github.js
+++ b/assets/js/github.js
@@ -95,7 +95,7 @@ export default async function (elements) {
 				})
 
 			wideLangBox
-				.getElementById("rect-mask")
+				.querySelector("mask")
 				.firstElementChild
 				.setAttribute("width", WideBoxBarWidth)
 
@@ -131,7 +131,7 @@ export default async function (elements) {
 				})
 
 			tallLangBox
-				.getElementById("rect-mask")
+				.querySelector("mask")
 				.firstElementChild
 				.setAttribute("width", tallBoxBarWidth)
 


### PR DESCRIPTION
It seems its just using `getElementById` that's broken in Safari, so this just changes it to `querySelector`. This wouldn't work if there was another `<mask>` before it, but as its the only one this should work fine. It does for me in Edge, Firefox, and Safari at least.